### PR TITLE
pyvo: Use blank background for widescreen videos

### DIFF
--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -143,7 +143,10 @@ def make_pyvo(
 
         duration = max(screen_vid.duration, speaker_vid.duration)
 
-        page = export_template.exported_slide(duration=duration)
+        if widescreen:
+            page = export_template.exported_slide('slide-blank', duration=duration)
+        else:
+            page = export_template.exported_slide(duration=duration)
         if logo:
             page |= apply_logo(export_template, logo, page.duration, 'logo')
         if widescreen:


### PR DESCRIPTION
This should prevent the talk details from appearing twice when
speaker video starts before the slides; see for example here:
https://www.youtube.com/watch?v=sMaqKNGUpQ0&feature=youtu.be