### PR TITLE
Add numpy includes to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup, Extension
 
 from Cython.Build import cythonize
+import numpy
 
 extensions = [
-    Extension("talk_video_maker.cdtw", ["cdtw.pyx"]),
+    Extension("talk_video_maker.cdtw", ["cdtw.pyx"],
+              include_dirs=[numpy.get_include()]),
 ]
 
 


### PR DESCRIPTION
When numpy is installed in a virtualenv, cythonize fails for missing
numpy header files.

Also, I found it much easier to install it into the virtualenv by issuing:

    $ pip install Cython numpy
    $ pip install -e /path/to/talk-video-maker

so the dependent libraries are just downloaded instead of compiling them.