### PR TITLE
Use ffmpeg concat protocol for multi-file input concatenation

### DIFF
--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -159,12 +159,16 @@ def make_pyvo(
                 raise ValueError('screencast has no audio, specify screen_offset manually')
             screen_offset = get_audio_offset(screen_vid, speaker_vid, max_stderr=5e-4)
 
+        screen_vid, speaker_vid = offset_video(screen_vid, speaker_vid,
+                                               screen_offset, mode=trim)
+
         if has_pillarbox:
             assert not widescreen
             screen_vid = screen_vid.cropped(screen_vid.width*3//4, screen_vid.height)
 
         if speaker_only:  # Speaker only but audio from screen recording
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-only', 'vid-only')
+            screen_vid = screen_vid.muted('video')
             screen_on_top = False
         elif widescreen:
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-wspeaker', 'slide-ws')
@@ -172,9 +176,6 @@ def make_pyvo(
         else:
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-speaker')
             screen_vid = screen_vid.resized_by_template(template, 'vid-screen')
-
-        screen_vid, speaker_vid = offset_video(screen_vid, speaker_vid,
-                                               screen_offset, mode=trim)
 
         if preview:
             speaker_vid = speaker_vid.trimmed(end=30)

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -131,7 +131,6 @@ def make_pyvo(
     last = export_template.exported_slide('slide-last', duration=7)
 
     qr_sizes = template.element_sizes['qrcode']
-    # last_sizes = template.element_sizes['slide-last']
     qrcode = qr.TextQR(url).resized(qr_sizes['w'], qr_sizes['h'])
     qrcode = qrcode.exported_slide(duration=last.duration)
     qrcode = qrcode.resized_by_template(template, 'qrcode', 'slide-last')
@@ -175,7 +174,7 @@ def make_pyvo(
 
         if speaker_only:  # Speaker only but audio from screen recording
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-only', 'vid-only')
-            screen_vid = screen_vid.muted('video')
+            screen_vid = screen_vid.without_streams('video')
             screen_on_top = False
         elif widescreen:
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-wspeaker', 'slide-ws')

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -80,6 +80,8 @@ def make_pyvo(
             help='Make the screencast span the whole screen, not just a 4:3 area'),
         has_pillarbox: opts.FlagOption(
             help='The screencast is pure 4:3 but recorded as 16:9'),
+        has_letterbox: opts.FlagOption(
+            help='The screencast is pure 16:9 but recorded as 4:3'),
         screen_on_top: opts.FlagOption(
             default=True,
             help='Put screencast on top of speaker video'),
@@ -165,8 +167,11 @@ def make_pyvo(
                                                screen_offset, mode=trim)
 
         if has_pillarbox:
-            assert not widescreen
+            widescreen = False
             screen_vid = screen_vid.cropped(screen_vid.width*3//4, screen_vid.height)
+        if has_letterbox:
+            widescreen = True
+            screen_vid = screen_vid.cropped(screen_vid.width, screen_vid.height*3//4)
 
         if speaker_only:  # Speaker only but audio from screen recording
             speaker_vid = speaker_vid.resized_by_template(template, 'vid-only', 'vid-only')

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -230,7 +230,8 @@ def make_pyvo(
     num = 0
     while os.path.exists(outname):
         num += 1
-        outname = '{}-{}.mkv'.format(outname[:-4].rstrip('-0123456789'), num)
+        fname, ext = os.path.splitext(outname)
+        outname = '{}-{}{}'.format(fname.rstrip('-0123456789'), num, ext)
 
     result.save()
     os.link(result.filename, outname)
@@ -238,8 +239,8 @@ def make_pyvo(
 
     metadata = {'speaker': speaker, 'title': title, 'date': date, 'event': event,
                 'lighting': lightning, 'url': url}
-    metaname = outname[:-3] + "yaml"
-    with open(metaname, "w") as metaf:
+    fname, _ = os.path.splitext(outname)
+    with open(fname + ".yaml", "w") as metaf:
         metaf.write(safe_dump(metadata, default_flow_style=False, allow_unicode=True))
 
     return result

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -4,6 +4,8 @@ import os.path
 import unicodedata
 import re
 
+from yaml import safe_dump
+
 from talk_video_maker import mainfunc, opts, qr
 from talk_video_maker.syncing import offset_video, get_audio_offset
 
@@ -229,5 +231,11 @@ def make_pyvo(
     result.save()
     os.link(result.filename, outname)
     print('Saved as {}'.format(outname))
+
+    metadata = {'speaker': speaker, 'title': title, 'date': date, 'event': event,
+                'lighting': lightning, 'url': url}
+    metaname = outname[:-3] + "yaml"
+    with open(metaname, "w") as metaf:
+        metaf.write(safe_dump(metadata, default_flow_style=False, allow_unicode=True))
 
     return result

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -238,7 +238,7 @@ def make_pyvo(
     print('Saved as {}'.format(outname))
 
     metadata = {'speaker': speaker, 'title': title, 'date': date, 'event': event,
-                'lighting': lightning, 'url': url}
+                'lighting': lightning, 'url': url, 'fname': os.path.basename(outname)}
     fname, _ = os.path.splitext(outname)
     with open(fname + ".yaml", "w") as metaf:
         metaf.write(safe_dump(metadata, default_flow_style=False, allow_unicode=True))

--- a/pyvo/make_vid.py
+++ b/pyvo/make_vid.py
@@ -238,7 +238,7 @@ def make_pyvo(
     print('Saved as {}'.format(outname))
 
     metadata = {'speaker': speaker, 'title': title, 'date': date, 'event': event,
-                'lighting': lightning, 'url': url, 'fname': os.path.basename(outname)}
+                'lightning': lightning, 'url': url, 'fname': os.path.basename(outname)}
     fname, _ = os.path.splitext(outname)
     with open(fname + ".yaml", "w") as metaf:
         metaf.write(safe_dump(metadata, default_flow_style=False, allow_unicode=True))

--- a/talk_video_maker/opts.py
+++ b/talk_video_maker/opts.py
@@ -1,7 +1,5 @@
 import argparse
 import glob
-import operator
-import functools
 import datetime
 import os
 
@@ -84,10 +82,8 @@ class VideoOption(Option):
         base = os.path.dirname(conf_path)
         if isinstance(value, str):
             filenames = fileglob(value, self.default, base)
-            inputs = [InputVideo(filename=n) for n in filenames]
-            if not inputs:
-                return None
-            value = functools.reduce(operator.add, inputs)
+            concats = "|".join(filenames)
+            value = InputVideo(filename="concat:" + concats)
         return value
 
 

--- a/talk_video_maker/opts.py
+++ b/talk_video_maker/opts.py
@@ -82,8 +82,13 @@ class VideoOption(Option):
         base = os.path.dirname(conf_path)
         if isinstance(value, str):
             filenames = fileglob(value, self.default, base)
-            concats = "|".join(filenames)
-            value = InputVideo(filename="concat:" + concats)
+            if len(filenames) > 1:
+                concats = "|".join(filenames)
+                value = InputVideo(filename="concat:" + concats)
+            elif len(filenames) == 1:
+                value = InputVideo(filename=filenames[0])
+            else:
+                value = None
         return value
 
 

--- a/talk_video_maker/syncing.py
+++ b/talk_video_maker/syncing.py
@@ -53,6 +53,17 @@ def offset_video(video_a, video_b, offset, mode='pad'):
         if video_b.duration < result_a.duration:
             result_a = result_a.trimmed(end=video_b.duration)
         result_b = video_b
+    elif mode == 'intersect':
+        if offset > 0:
+            result_a = video_a
+            result_b = _cut_video(video_b, -1, offset)
+        else:
+            result_a = _cut_video(video_a, 1, offset)
+            result_b = video_b
+        if result_b.duration < result_a.duration:
+            result_a = result_a.trimmed(end=result_b.duration)
+        if result_a.duration < result_b.duration:
+            result_b = result_b.trimmed(end=result_a.duration)
     else:
         raise ValueError('bad mode')
     return result_a, result_b

--- a/talk_video_maker/videos.py
+++ b/talk_video_maker/videos.py
@@ -411,7 +411,7 @@ def generate_filter_graph(streams):
 
     def quote(s):
         d = {
-            ':': r'\:',
+            ':': r'\\:',
             '\\': r'\\\\',
             "'": r"\\\'",
             "[": r"\[",

--- a/talk_video_maker/videos.py
+++ b/talk_video_maker/videos.py
@@ -104,9 +104,12 @@ class AVObject(objects.Object):
         streams = filter_streams(streams, {'audio'}, 'aformat', args)
         return AVObject(streams, acodec='pcm_s16le', format='wav')
 
-    def muted(self, mute_type='audio'):
-        streams = [s for s in self.streams if s.type != mute_type]
+    def without_streams(self, type):
+        streams = [s for s in self.streams if s.type != type]
         return AVObject(streams)
+
+    def muted(self):
+        return self.without_streams('audio')
 
     def faded(self, duration, fade_type, start_time=0):
         streams = self.streams

--- a/talk_video_maker/videos.py
+++ b/talk_video_maker/videos.py
@@ -104,8 +104,8 @@ class AVObject(objects.Object):
         streams = filter_streams(streams, {'audio'}, 'aformat', args)
         return AVObject(streams, acodec='pcm_s16le', format='wav')
 
-    def muted(self):
-        streams = [s for s in self.streams if s.type != 'audio']
+    def muted(self, mute_type='audio'):
+        streams = [s for s in self.streams if s.type != mute_type]
         return AVObject(streams)
 
     def faded(self, duration, fade_type, start_time=0):


### PR DESCRIPTION
Fix #5 -- audible gap on the splice point of input files.
On the downside, input files now have to be binary concatenable,
like MPEG-TS, which is true only for camcorder recordings and
similar.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>